### PR TITLE
Switch from a local variable to using TeslaMate's charge_limit_soc

### DIFF
--- a/PVCharge.py
+++ b/PVCharge.py
@@ -90,18 +90,18 @@ while True:
                         logging.info(f"Car charging, Available Energy Reduced, new rate: {config['MIN_CHARGE']} successfully set")
                         Messages.client.publish(topic=config["TOPIC_CHARGE_RATE"], payload=config["MIN_CHARGE"], qos=1)
                     else:
-                        logging.warning(f"Car charging, Available Energy Reduced, new rate was NOT successfully set")
+                        logging.warning("Car charging, Available Energy Reduced, new rate was NOT successfully set")
 
                 else:    # We are already at min charge
                     # Wait configured time before stopping
                     waited_long_enough, stop_charging_time = routines.check_elapsed_time(loop_time, stop_charging_time, config["DELAYED_STOP_TIME"])
                     if waited_long_enough:
                         if Car.stop_charging():
-                            logging.info(f"Car charging, Available Energy Reduced, charging was successfully stopped")
+                            logging.info("Car charging, Available Energy Reduced, charging was successfully stopped")
                             car_is_charging = False
                             stop_charging_time = 0
                         else:
-                            logging.warning(f"Car charging, Available Energy Reduced, charging was NOT successfully stopped")
+                            logging.warning("Car charging, Available Energy Reduced, charging was NOT successfully stopped")
                     else:
                         logging.info(f"Car charging, Available Energy Reduced, charging at min rate, stopping in: {round(config['DELAYED_STOP_TIME'] - (loop_time - stop_charging_time))} seconds")
 
@@ -114,26 +114,20 @@ while True:
                         wake_states = ["asleep", "suspended"]
                         if Messages.var_topic_teslamate_state in wake_states:    # Only wake car if it's asleep
                             if Car.wake():
-                                logging.info(f"Car is NOT charging, Energy is Available, car woken successfully")
+                                logging.info("Car is NOT charging, Energy is Available, car woken successfully")
                                 time.sleep(5)    # Wait until car is awake
                             else:
-                                logging.warning(f"Car was NOT woken successfully")
+                                logging.warning("Car was NOT woken successfully")
                         if Car.start_charging():
-                            logging.info(f"Car Started Charging Successfully")
+                            logging.info("Car Started Charging Successfully")
                             time.sleep(10)    # Wait until charging is fully started
                             if Energy.verify_new_charge_rate(config["MIN_CHARGE"]):
-                                logging.info(f"Charge Rate is greater than min charge")
+                                logging.info("Charge Rate is greater than min charge")
                                 car_is_charging = True
                                 start_charging_time = 0
                                 # Optionally we could set a new charge rate here
                         else:
-                            logging.warning(f"Car Charging NOT Started Successfully")
-                            # Detect one cause of not being able to start successfully
-                            if (Messages.var_topic_teslamate_charge_limit_soc != 0) and (config["MAX_CHARGE_LIMIT"] > Messages.var_topic_teslamate_charge_limit_soc):
-                                message = f"Bad Configuration Detected!\nMax Charge Limit of: {config['MAX_CHARGE_LIMIT']} > Charge Limit of Tesla App: {Messages.var_topic_teslamate_charge_limit_soc}\nPausing 30 seconds"
-                                logging.warning(message)
-                                Messages.client.publish(topic=config["TOPIC_STATUS"], payload=message, qos=1)
-                                time.sleep(30)
+                            logging.warning("Car Charging NOT Started Successfully")
                     else:
                         logging.info(f"Car is NOT charging, Energy is Available, starting in: {round(config['DELAYED_START_TIME'] - (loop_time - start_charging_time))} seconds")
 
@@ -152,15 +146,15 @@ while True:
 
     else:    # We aren't allowed to charge
         if car_is_charging:
-            if Messages.var_topic_teslamate_battery_level == config["MAX_CHARGE_LIMIT"]:
-                logging.info(f"Completed charge to: {config['MAX_CHARGE_LIMIT']}% limit, stopping charge")
+            if Messages.var_topic_teslamate_battery_level == Messages.var_topic_teslamate_charge_limit_soc:
+                logging.info(f"Completed charge to: {Messages.var_topic_teslamate_charge_limit_soc}% limit, stopping charge")
             else:
-                logging.info(f"Car not allowed to charge, stopping charge")
+                logging.info("Car not allowed to charge, stopping charge")
             Car.set_charge_rate(config["MIN_CHARGE"])    # Set charge rate to min charge, to reset for next time
             if Car.stop_charging():    # Command will fail if charging has already stopped
-                logging.info(f"Charge Stopping, stopped successfully")
+                logging.info("Charge Stopping, stopped successfully")
             else:
-                logging.info(f"Charge Stopping, did NOT stop successfully")
+                logging.info("Charge Stopping, did NOT stop successfully")
             car_is_charging = False    # Clear the flag even if it fails
 
     # Wait configured time before reporting status

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ An adaptive charging controller for your Tesla, enabling you to direct excess so
 - <a href="https://www.tesla.com/">Tesla vehicle</a>
 - Configured <a href="https://github.com/teslamotors/vehicle-command">Tesla Vehicle Command SDK</a> environment with <a href="https://github.com/teslamotors/vehicle-command/tree/main/cmd/tesla-control">tesla-control</a> available
 - <a href="https://github.com/teslamate-org/teslamate">TeslaMate</a>
-- <a href="https://www.egauge.net">eGauge solar monitoring</a>, with a CT on the charger circuit
+- <a href="https://www.egauge.net">eGauge solar monitoring</a> with a CT on the charger circuit
 - Linux computer with Bluetooth, such as a <a href="https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/">Raspberry Pi Zero 2 W</a>
 
 ## Optional
-- <a href="https://www.home-assistant.io/">Home Assistant</a> or another <a href="https://apps.apple.com/us/app/mqttool/id1085976398">MQTT client</a> to adjust the MQTT option for after-dark charging<br><br>
+- <a href="https://www.home-assistant.io/">Home Assistant</a> or another <a href="https://apps.apple.com/us/app/mqttool/id1085976398">MQTT client</a> to adjust the option for after-dark charging<br><br>
 
 ## Tesla Vehicle Command SDK
 
 PVCharge uses <a href="https://github.com/teslamotors/vehicle-command/tree/main/cmd/tesla-control">tesla-control</a> in the <a href="https://github.com/teslamotors/vehicle-command">Tesla Vehicle Command SDK</a> to communicate with your car over local Bluetooth
 
-- Note: To support Waking over BLE, please apply this <a href="https://github.com/teslamotors/vehicle-command/pull/106">PR:106</a>
+- Note: To support Waking over Bluetooth, please apply this <a href="https://github.com/teslamotors/vehicle-command/pull/106">PR:106</a>
 
 Here are a few hints to help complete the tesla-control installation
 
@@ -54,9 +54,9 @@ sudo systemctl start PVCharge.service</pre>
 PVCharge waits for 3 conditions to be communicated over MQTT from <a href="https://docs.teslamate.org/docs/integrations/mqtt">Teslamate</a>
 - Car location is "Home" <code>teslamate/cars/$car_id/geofence</code>
 - Car is plugged in <code>teslamate/cars/$car_id/plugged_in</code>
-- Car battery level below 80% <code>teslamate/cars/$car_id/battery_level</code> (Configurable in config.toml)<br>
-#### When those conditions are satisfied, it will attempt to start charging
-#### As available PV output changes throughout the day, charging rate will be adjusted
+- Car battery level is below the App limit <code>teslamate/cars/$car_id/battery_level</code><br>
+#### When those conditions are satisfied, it will attempt to start charging, when solar energy is available
+#### As PV output changes throughout the day, charging rate will be adjusted to use the excess energy
 
 ## Status
 PVCharge publishes status on MQTT

--- a/example_config.toml
+++ b/example_config.toml
@@ -16,7 +16,6 @@ TOPIC_CHARGE_RATE = "topic_base/new_charge_rate"
 
 # Control loop parameters
 MIN_CHARGE = 7           # Slowest allowed charge rate (Amps)
-MAX_CHARGE_LIMIT = 80    # Max charge limit (%)
 SLOW_POLLING = 30        # Charging disabled, control topic check interval (seconds)
 SLOW_POLLING_CHK = 5     # Charging disabled, prevent non-solar charge check interval (seconds)
 FAST_POLLING = 1         # Charging enabled, loop delay (seconds)

--- a/routines.py
+++ b/routines.py
@@ -10,7 +10,6 @@ from egauge import webapi
 from egauge.webapi.device import Register, Local
 import paho.mqtt.client as mqtt
 
-
 # Load parameters from .env
 load_dotenv()
 # Load config file
@@ -82,10 +81,10 @@ class PowerUsage:
             self.sample_sensor()
             # Use round() on the verify step (vs math.floor()) to prevent constant requests for the same value
             if round(self.charge_rate_sensor) >= new_charge_rate:
-                logging.debug(f"New charge rate verified")
+                logging.debug("New charge rate verified")
                 return True
             time.sleep(0.5)
-        logging.debug(f"New charge rate NOT verified")
+        logging.debug("New charge rate NOT verified")
         return False
 
     def sufficient_generation(self, min_charge):
@@ -186,7 +185,6 @@ class MqttCallbacks:
         self.topic_teslamate_battery_level = config["TOPIC_TESLAMATE_BATTERY_LEVEL"]
         self.topic_teslamate_charge_limit_soc = config["TOPIC_TESLAMATE_CHARGE_LIMIT_SOC"]
         self.topic_teslamate_state = config["TOPIC_TESLAMATE_STATE"]
-        self.max_charge_limit = config["MAX_CHARGE_LIMIT"]
         if config["PREVENT_NON_SOLAR_CHARGE"] == "True":
             self.var_topic_prevent_non_solar_charge = True
         else:
@@ -260,9 +258,9 @@ class MqttCallbacks:
         self.var_topic_teslamate_state = msg.payload.decode("utf-8")
 
     def calculate_charge_tesla(self):
-        # Charge if: Car is at Home, Car is plugged in, and battery < max_charge_limit
+        # Charge if: Car is at Home, Car is plugged in, and battery < charge_limit_soc
         if (self.var_topic_teslamate_geofence & self.var_topic_teslamate_plugged_in &
-                (self.var_topic_teslamate_battery_level < self.max_charge_limit)):
+                (self.var_topic_teslamate_battery_level < self.var_topic_teslamate_charge_limit_soc)):
             return True
         else:
             return False


### PR DESCRIPTION
Eliminated MAX_CHARGE_LIMIT variable in example_config.toml
Note, MAX_CHARGE_LIMIT variable will be unused in existing config.toml files, please remove.
Removed some unnecessary f-strings
Updated README to clarify a bit.