### PR TITLE
Added charge override capability

### DIFF
--- a/PVCharge.py
+++ b/PVCharge.py
@@ -108,28 +108,31 @@ while True:
         else:    # Car isn't charging, should it be?
             if Energy.sufficient_generation(config["MIN_CHARGE"]):    # If we have enough sun to charge
                 if round(Energy.charge_rate_sensor) < config["MIN_CHARGE"]:	   # Make sure car isn’t already charging
-                    # Wait configured time before starting
-                    waited_long_enough, start_charging_time = routines.check_elapsed_time(loop_time, start_charging_time, config["DELAYED_START_TIME"])
-                    if waited_long_enough:
-                        wake_states = ["asleep", "suspended"]
-                        if Messages.var_topic_teslamate_state in wake_states:    # Only wake car if it's asleep
-                            if Car.wake():
-                                logging.info("Car is NOT charging, Energy is Available, car woken successfully")
-                                time.sleep(5)    # Wait until car is awake
+                    if ((Messages.var_topic_teslamate_charge_limit_soc - Messages.var_topic_teslamate_battery_level) > 1):    # If we are charging at least 1%
+                        # Wait configured time before starting
+                        waited_long_enough, start_charging_time = routines.check_elapsed_time(loop_time, start_charging_time, config["DELAYED_START_TIME"])
+                        if waited_long_enough:
+                            wake_states = ["asleep", "suspended"]
+                            if Messages.var_topic_teslamate_state in wake_states:    # Only wake car if it's asleep
+                                if Car.wake():
+                                    logging.info("Car is NOT charging, Energy is Available, car woken successfully")
+                                    time.sleep(5)    # Wait until car is awake
+                                else:
+                                    logging.warning("Car was NOT woken successfully")
+                            if Car.start_charging():
+                                logging.info("Car Started Charging Successfully")
+                                time.sleep(10)    # Wait until charging is fully started
+                                if Energy.verify_new_charge_rate(config["MIN_CHARGE"]):
+                                    logging.info("Charge Rate is greater than min charge")
+                                    car_is_charging = True
+                                    start_charging_time = 0
+                                    # Optionally we could set a new charge rate here
                             else:
-                                logging.warning("Car was NOT woken successfully")
-                        if Car.start_charging():
-                            logging.info("Car Started Charging Successfully")
-                            time.sleep(10)    # Wait until charging is fully started
-                            if Energy.verify_new_charge_rate(config["MIN_CHARGE"]):
-                                logging.info("Charge Rate is greater than min charge")
-                                car_is_charging = True
-                                start_charging_time = 0
-                                # Optionally we could set a new charge rate here
+                                logging.warning("Car Charging NOT Started Successfully")
                         else:
-                            logging.warning("Car Charging NOT Started Successfully")
+                            logging.info(f"Car is NOT charging, Energy is Available, starting in: {round(config['DELAYED_START_TIME'] - (loop_time - start_charging_time))} seconds")
                     else:
-                        logging.info(f"Car is NOT charging, Energy is Available, starting in: {round(config['DELAYED_START_TIME'] - (loop_time - start_charging_time))} seconds")
+                        logging.debug("Attempting to charge with only 1% remaining")
 
                 else:    # Car is already charging, set the flag
                     car_is_charging = True

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An adaptive charging controller for your Tesla, enabling you to direct excess so
 - Linux computer with Bluetooth, such as a <a href="https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/">Raspberry Pi Zero 2 W</a>
 
 ## Optional
-- <a href="https://www.home-assistant.io/">Home Assistant</a> or another <a href="https://apps.apple.com/us/app/mqttool/id1085976398">MQTT client</a> to adjust the option for after-dark charging<br><br>
+- <a href="https://www.home-assistant.io/">Home Assistant</a> or another <a href="https://apps.apple.com/us/app/mqttool/id1085976398">MQTT client</a> to adjust the options for after-dark charging, and delayed charging<br><br>
 
 ## Tesla Vehicle Command SDK
 
@@ -64,10 +64,17 @@ PVCharge publishes status on MQTT
 - Current charge rate <code>topic_base/new_charge_rate</code>
 
 ## Control
-The behavior of after-hours charging is controlled by MQTT: <code>topic_base/prevent_non_solar_charging</code><br>
+- The behavior of after-hours charging is controlled by MQTT: <code>topic_base/prevent_non_solar_charging</code><br>
 <dl>
-<dt>True</dt> <dd>PVCharge will prevent charging when insufficient PV output is available</dd>
-<dt>False</dt> <dd>PVCharge will ignore charging when insufficient PV output is available (default, Configurable in config.toml)</dd>
+  <dt>True</dt> <dd>PVCharge will prevent charging when insufficient PV output is available</dd>
+  <dt>False</dt> <dd>PVCharge will ignore charging when insufficient PV output is available (default, Configurable in config.toml)</dd>
+</dl><br>
+
+- The ability to delay charging is controlled by: <code>topic_base/charge_delay</code><br>
+<dl>
+  <dt>"delay"</dt> <dd>charging is delayed for 1 hour</dd>
+  <dt>"##" (number)</dt> <dd>charging is delayed by the indicated number of minutes</dd>
+  <dt>other text (i.e. "cancel")</dt> <dd>resume normal charging</dd>
 </dl>
 
 ## Troubleshooting

--- a/example_config.toml
+++ b/example_config.toml
@@ -5,6 +5,7 @@ PREVENT_NON_SOLAR_CHARGE = "False"  # Default for after-hours charging, unless c
 
 # MQTT Control topics
 TOPIC_PREVENT_NON_SOLAR_CHARGE =   "topic_base/prevent_non_solar_charge"
+TOPIC_CHARGE_DELAY =               "topic_base/charge_delay"    # Commands: "delay" = delay charge for 1 hour, ## = minutes to delay charge, (other text, i.e. "cancel") = resume normal charge
 TOPIC_TESLAMATE_GEOFENCE =         "teslamate/cars/$car_id/geofence"
 TOPIC_TESLAMATE_PLUGGED_IN =       "teslamate/cars/$car_id/plugged_in"
 TOPIC_TESLAMATE_BATTERY_LEVEL =    "teslamate/cars/$car_id/battery_level"


### PR DESCRIPTION
Added ability to override/delay charging for a period of time.  Useful when an intermittent load like a dryer is causing more grid power usage than you would like.  Delaying by ~30min would allow smoother charging.
New MQTT control topic: topic_base/charge_delay
Commands: "delay" = delay charge for 1 hour, ## = minutes to delay charge, (other text, i.e. "cancel") = resume normal charge

NOTE, new parameter TOPIC_CHARGE_DELAY added to example_config.toml  Please copy line into your config.toml