### PR TITLE
Update polling intervals

### DIFF
--- a/PVCharge.py
+++ b/PVCharge.py
@@ -147,6 +147,16 @@ while True:
             car_is_charging = False    # Clear the flag even if it fails
 
         else:
+            if prevent_non_solar_charge:    # Check for car unexpectedly charging
+                logging.debug("Slow poll wait, ensure car isn't charging")
+                Energy.sample_sensor()
+                if round(Energy.charge_rate_sensor) >= config["MIN_CHARGE"]:
+                    if Car.stop_charging():     # Stop if it is charging
+                        logging.info("Slow poll, Car discovered charging and was stopped successfully")
+                        car_is_charging = False
+                    else:
+                        logging.warning("Slow poll, Car discovered charging and was NOT stopped successfully")
+
             # We are either: manually delayed, car isn't ready to charge, or sun is down; just wait
             logging.debug("Slow poll wait")
             time.sleep(config["SLOW_POLLING"])

--- a/PVCharge.py
+++ b/PVCharge.py
@@ -143,6 +143,7 @@ while True:
             if round(Energy.charge_rate_sensor) >= config["MIN_CHARGE"]:
                 if Car.stop_charging():     # Stop if it is charging
                     logging.info("Slow poll, Car discovered charging and was stopped successfully")
+                    time.sleep(2)    # Delay to allow stop command to complete
                 else:
                     logging.warning("Slow poll, Car discovered charging and was NOT stopped successfully")
                 Energy.sample_sensor()    # Force sensor refresh to increase accuracy of subsequent loop

--- a/PVCharge.py
+++ b/PVCharge.py
@@ -145,7 +145,7 @@ while True:
                     logging.info("Slow poll, Car discovered charging and was stopped successfully")
                 else:
                     logging.warning("Slow poll, Car discovered charging and was NOT stopped successfully")
-                    Energy.sample_sensor()    # Force sensor refresh to ensure accurate subsequent loop
+                    Energy.sample_sensor()    # Force sensor refresh to increase accuracy of subsequent loop
             else:
                 # Prevent non_solar_charge or delay, wait condition
                 time.sleep(config["SLOW_POLLING"])
@@ -157,7 +157,7 @@ while True:
     # Wait configured time before reporting status
     report_is_due, report_time = routines.check_elapsed_time(loop_time, report_time, config["REPORT_DELAY"])
     if report_is_due:
-        status = Energy.status_report(charge_tesla, charge_delay, car_is_charging, new_sample=True)
+        status = Energy.status_report(charge_tesla, charge_delay, sun_up, car_is_charging, new_sample=True)
         logging.info(f"{status}")
         Messages.client.publish(topic=config["TOPIC_STATUS"], payload=status, qos=1)
         report_time = loop_time    # Reset counter for next loop

--- a/PVCharge.py
+++ b/PVCharge.py
@@ -145,7 +145,7 @@ while True:
                     logging.info("Slow poll, Car discovered charging and was stopped successfully")
                 else:
                     logging.warning("Slow poll, Car discovered charging and was NOT stopped successfully")
-                    Energy.sample_sensor()    # Force sensor refresh to increase accuracy of subsequent loop
+                Energy.sample_sensor()    # Force sensor refresh to increase accuracy of subsequent loop
             else:
                 # Prevent non_solar_charge or delay, wait condition
                 time.sleep(config["SLOW_POLLING"])

--- a/example_config.toml
+++ b/example_config.toml
@@ -17,9 +17,9 @@ TOPIC_CHARGE_RATE = "topic_base/new_charge_rate"
 
 # Control loop parameters
 MIN_CHARGE = 7           # Slowest allowed charge rate (Amps)
-SLOW_POLLING = 30        # Charging disabled, control topic check interval (seconds)
-SLOW_POLLING_CHK = 5     # Charging disabled, prevent non-solar charge check interval (seconds)
+MIN_SOLAR = 500          # Minimum generation to enable polling (Watts)
+SLOW_POLLING = 60        # Charging disabled, control topic check interval (seconds)
 FAST_POLLING = 1         # Charging enabled, loop delay (seconds)
 DELAYED_START_TIME = 10	 # When Energy is Available how long do we wait before starting charge (seconds)
 DELAYED_STOP_TIME = 90   # When Available Energy is Reduced how long do we wait before stopping charge (seconds)
-REPORT_DELAY = 60        # Send status string to MQTT every x (seconds), delayed by as much as SLOW_POLLING_CHK when charging disabled
+REPORT_DELAY = 60        # Send status string to MQTT every x (seconds)

--- a/routines.py
+++ b/routines.py
@@ -272,7 +272,11 @@ class MqttCallbacks:
         if msg.payload.decode("utf-8") == "true":
             if (not self.var_topic_teslamate_plugged_in) and self.var_topic_prevent_non_solar_charge:
                 # If previous state was False, and prevent_non_solar_charge is True, stop charging immediately
-                self.car_cmd.stop_charging()
+                time.sleep(4)    # Delay to ensure success of the stop command
+                if self.car_cmd.stop_charging():
+                    logging.info("Charging stopped upon plugin, prevent_non_solar_charge active")
+                else:
+                    logging.warning("Charging NOT stopped upon plugin, prevent_non_solar_charge active")
             self.var_topic_teslamate_plugged_in = True
         else:
             self.var_topic_teslamate_plugged_in = False

--- a/routines.py
+++ b/routines.py
@@ -101,14 +101,14 @@ class PowerUsage:
         else:
             return False
 
-    def status_report(self, charge_tesla, charge_delay, car_is_charging, new_sample):
+    def status_report(self, charge_tesla, charge_delay, sun_up, car_is_charging, new_sample):
         if new_sample:
             self.calculate_charge_rate(new_sample)
         # Build status string
         status = "Status: "
-        if charge_tesla == True and charge_delay == False:
+        if ((charge_tesla and sun_up) and not charge_delay):
             status += "En:1 "
-        elif charge_tesla == True and charge_delay == True:
+        elif charge_delay == True:
             status += "Delay "
         else:
             status += "En:0 "

--- a/routines.py
+++ b/routines.py
@@ -52,19 +52,19 @@ class PowerUsage:
         """Sample registers and convert kW to W"""
         self.register_sample = Register(self.my_eGauge, {"rate": "True", "time": "now"})
         self.generation_reg = self.register_sample.pq_rate(self.eGauge_gen).value * 1000
-        logging.debug(f"   Generation reg: {self.generation_reg}")
+        logging.debug(f"   Generation reg: {self.generation_reg:.0f}")
         self.usage_reg = self.register_sample.pq_rate(self.eGauge_use).value * 1000
-        logging.debug(f"        Usage reg: {self.usage_reg}")
+        logging.debug(f"        Usage reg: {self.usage_reg:.0f}")
         self.tesla_charger_reg = self.register_sample.pq_rate(self.eGauge_charger).value * 1000
-        logging.debug(f"Tesla charger reg: {self.tesla_charger_reg}")
+        logging.debug(f"Tesla charger reg: {self.tesla_charger_reg:.0f}")
 
     def sample_sensor(self):
         self.sensor_sample = Local(self.my_eGauge, "l=L1:L2&s=all")
         self.charger_voltage_sensor = (self.sensor_sample.rate("L1", "n") +
                                        self.sensor_sample.rate("L2", "n"))
-        logging.debug(f"Charger voltage sensor: {self.charger_voltage_sensor}")
+        logging.debug(f" Charger voltage sensor: {self.charger_voltage_sensor:.2f}")
         self.charge_rate_sensor = self.sensor_sample.rate(self.eGauge_charger_sensor, "n")
-        logging.debug(f"    Charge rate sensor: {self.charge_rate_sensor}")
+        logging.debug(f"     Charge rate sensor: {self.charge_rate_sensor:.2f}")
 
     def calculate_charge_rate(self, new_sample):
         if new_sample:
@@ -73,7 +73,7 @@ class PowerUsage:
         # Calculate the charge rate
         self.new_charge_rate = ((self.generation_reg - (self.usage_reg - self.tesla_charger_reg)) /
                                 self.charger_voltage_sensor)
-        logging.debug(f"New charge rate: {self.new_charge_rate}")
+        logging.debug(f"New charge rate: {self.new_charge_rate:.2f}")
         return self.new_charge_rate
 
     def verify_new_charge_rate(self, new_charge_rate):


### PR DESCRIPTION
Streamline polling structure to eliminate duplicate code
-Added sun detection threshold with new config.toml variable MIN_SOLAR
-Polling drops down to once per minute (configurable through SLOW_POLLING in config.toml) when the sun is down, even if car is plugged in
-Added immediate charge stop (4 sec delay) upon plugin when prevent_non_solar_charge is True
-Improved readability of DEBUG messages and more regular status reports