### PR TITLE
Adding support for TeslaBleHttpProxy

### DIFF
--- a/PVCharge.py
+++ b/PVCharge.py
@@ -25,7 +25,7 @@ else:
 
 # Initialize classes
 Energy = routines.PowerUsage()
-if config["ENABLE_TESLA_PROXY"] == True:
+if config["ENABLE_TESLA_PROXY"] == "True":
     Car = routines.TeslaProxy()
 else:
     Car = routines.TeslaCommands()

--- a/PVCharge.py
+++ b/PVCharge.py
@@ -59,6 +59,7 @@ while True:
                 if (new_charge_rate != round(Energy.charge_rate_sensor)) and (round(Energy.charge_rate_sensor) != 0):
                     # Set new charge rate
                     if Car.set_charge_rate(new_charge_rate) == True:
+                        time.sleep(5)
                         if Energy.verify_new_charge_rate(new_charge_rate):
                             logging.info(f"Car charging, new rate: {new_charge_rate} successfully set")
                             Messages.client.publish(topic=config["TOPIC_CHARGE_RATE"], payload=new_charge_rate, qos=1)
@@ -69,6 +70,7 @@ while True:
                 if round(Energy.charge_rate_sensor) > config["MIN_CHARGE"]:    # If we are charging at anything greater than min charge
                     # Set charge rate to min charge
                     if Car.set_charge_rate(config["MIN_CHARGE"]) == True:
+                        time.sleep(5)
                         logging.info(f"Car charging, Available Energy Reduced, new rate: {config['MIN_CHARGE']} successfully set")
                         Messages.client.publish(topic=config["TOPIC_CHARGE_RATE"], payload=config["MIN_CHARGE"], qos=1)
                     else:
@@ -79,6 +81,7 @@ while True:
                     waited_long_enough, stop_charging_time = routines.check_elapsed_time(loop_time, stop_charging_time, config["DELAYED_STOP_TIME"])
                     if waited_long_enough:
                         if Car.stop_charging() == True:
+                            time.sleep(5)
                             logging.info("Car charging, Available Energy Reduced, charging was successfully stopped")
                             car_is_charging = False
                             stop_charging_time = 0

--- a/PVCharge.py
+++ b/PVCharge.py
@@ -22,10 +22,15 @@ elif config["LOG_LEVEL"] == "DEBUG":
 else:
     logging.warning("Unknown logging level")
 
+# Test if we have parameters for TeslaBleHttpProxy
+if "ENABLE_TESLA_PROXY" in config:
+    tesla_proxy_config_exists = config["ENABLE_TESLA_PROXY"]
+else:
+    tesla_proxy_config_exists = "False"
 
 # Initialize classes
 Energy = routines.PowerUsage()
-if config["ENABLE_TESLA_PROXY"] == "True":
+if tesla_proxy_config_exists == "True":
     logging.debug("Using TeslaProxy")
     Car = routines.TeslaProxy()
 else:

--- a/PVCharge.py
+++ b/PVCharge.py
@@ -26,8 +26,10 @@ else:
 # Initialize classes
 Energy = routines.PowerUsage()
 if config["ENABLE_TESLA_PROXY"] == "True":
+    logging.debug("Using TeslaProxy")
     Car = routines.TeslaProxy()
 else:
+    logging.debug("Using TeslaCommands")
     Car = routines.TeslaCommands()
 Messages = routines.MqttCallbacks()
 

--- a/PVCharge.py
+++ b/PVCharge.py
@@ -59,7 +59,6 @@ while True:
                 if (new_charge_rate != round(Energy.charge_rate_sensor)) and (round(Energy.charge_rate_sensor) != 0):
                     # Set new charge rate
                     if Car.set_charge_rate(new_charge_rate) == True:
-                        time.sleep(5)
                         if Energy.verify_new_charge_rate(new_charge_rate):
                             logging.info(f"Car charging, new rate: {new_charge_rate} successfully set")
                             Messages.client.publish(topic=config["TOPIC_CHARGE_RATE"], payload=new_charge_rate, qos=1)
@@ -70,7 +69,6 @@ while True:
                 if round(Energy.charge_rate_sensor) > config["MIN_CHARGE"]:    # If we are charging at anything greater than min charge
                     # Set charge rate to min charge
                     if Car.set_charge_rate(config["MIN_CHARGE"]) == True:
-                        time.sleep(5)
                         logging.info(f"Car charging, Available Energy Reduced, new rate: {config['MIN_CHARGE']} successfully set")
                         Messages.client.publish(topic=config["TOPIC_CHARGE_RATE"], payload=config["MIN_CHARGE"], qos=1)
                     else:
@@ -81,7 +79,6 @@ while True:
                     waited_long_enough, stop_charging_time = routines.check_elapsed_time(loop_time, stop_charging_time, config["DELAYED_STOP_TIME"])
                     if waited_long_enough:
                         if Car.stop_charging() == True:
-                            time.sleep(5)
                             logging.info("Car charging, Available Energy Reduced, charging was successfully stopped")
                             car_is_charging = False
                             stop_charging_time = 0

--- a/PVCharge.py
+++ b/PVCharge.py
@@ -22,21 +22,20 @@ elif config["LOG_LEVEL"] == "DEBUG":
 else:
     logging.warning("Unknown logging level")
 
-# Test if we have parameters for TeslaBleHttpProxy
-if "ENABLE_TESLA_PROXY" in config:
-    tesla_proxy_config_exists = config["ENABLE_TESLA_PROXY"]
-else:
-    tesla_proxy_config_exists = "False"
 
 # Initialize classes
 Energy = routines.PowerUsage()
-if tesla_proxy_config_exists == "True":
-    logging.debug("Using TeslaProxy")
-    Car = routines.TeslaProxy()
+Messages = routines.MqttCallbacks()
+if "ENABLE_TESLA_PROXY" in config:
+    if config["ENABLE_TESLA_PROXY"] == "True":
+        logging.debug("Using TeslaProxy")
+        Car = routines.TeslaProxy()
+    else:
+        logging.debug("Using TeslaCommands")
+        Car = routines.TeslaCommands()
 else:
     logging.debug("Using TeslaCommands")
     Car = routines.TeslaCommands()
-Messages = routines.MqttCallbacks()
 
 # Control loop variables
 car_is_charging = False

--- a/PVCharge.py
+++ b/PVCharge.py
@@ -25,7 +25,8 @@ else:
 
 # Initialize classes
 Energy = routines.PowerUsage()
-Car = routines.TeslaCommands()
+#Car = routines.TeslaCommands()
+Car = routines.TeslaProxy()
 Messages = routines.MqttCallbacks()
 
 # Control loop variables

--- a/PVCharge.py
+++ b/PVCharge.py
@@ -25,8 +25,10 @@ else:
 
 # Initialize classes
 Energy = routines.PowerUsage()
-#Car = routines.TeslaCommands()
-Car = routines.TeslaProxy()
+if config["ENABLE_TESLA_PROXY"] == True:
+    Car = routines.TeslaProxy()
+else:
+    Car = routines.TeslaCommands()
 Messages = routines.MqttCallbacks()
 
 # Control loop variables

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An adaptive charging controller for your Tesla, enabling you to direct excess so
 
 ## Requirements
 - <a href="https://www.tesla.com/">Tesla vehicle</a>
-- Configured <a href="https://github.com/teslamotors/vehicle-command">Tesla Vehicle Command SDK</a> environment with <a href="https://github.com/teslamotors/vehicle-command/tree/main/cmd/tesla-control">tesla-control</a> available
+- Configured <a href="https://github.com/teslamotors/vehicle-command">Tesla Vehicle Command SDK</a> environment with <a href="https://github.com/teslamotors/vehicle-command/tree/main/cmd/tesla-control">tesla-control</a> available OR use the <a href="https://github.com/wimaha/TeslaBleHttpProxy">TeslaBleHttpProxy</a> (NEW!)
 - <a href="https://github.com/teslamate-org/teslamate">TeslaMate</a>
 - <a href="https://www.egauge.net">eGauge solar monitoring</a> with a CT on the charger circuit
 - Linux computer with Bluetooth, such as a <a href="https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/">Raspberry Pi Zero 2 W</a>
@@ -26,6 +26,12 @@ tesla-keygen -key-file /home/pi/.local/share/keyrings/private_key.pem create > p
 
 While in the car, pair with this command:
 tesla-control -ble add-key-request public_key.pem owner cloud_key</pre>
+
+## TeslaBleHttpProxy
+To use TeslaBleHttpProxy (not required if you are using <a href="https://github.com/teslamotors/vehicle-command/tree/main/cmd/tesla-control">tesla-control</a>), please follow the installation & configuration instructions <a href="https://github.com/wimaha/TeslaBleHttpProxy">here</a>
+- Add the PROXY_HOST parameter to your .env file (see example.env)
+- Enable use of the proxy by adding the ENABLE_TESLA_PROXY parameter to your config.toml file (see example_config.toml)<br>
+- Note, when TeslaBleHttpProxy is running it seems to take over local bluetooth hardware.  Please stop the proxy before switching back to the <a href="https://github.com/teslamotors/vehicle-command/tree/main/cmd/tesla-control">tesla-control</a> library.
 
 ## PVCharge Installation
 - Install Python (3.11+) and Git using your package manager<br>

--- a/example.env
+++ b/example.env
@@ -13,6 +13,9 @@ export TESLA_VIN='Tesla VIN'
 export TESLA_KEY_FILE='private key location, i.e. /home/pi/.local/share/keyrings/private_key.pem'
 TESLA_CONTROL_BIN='Tesla control bin location, i.e. /home/pi/go/bin/tesla-control'
 
+#TeslaBleHttpProxy parameters
+PROXY_HOST='proxy local ip:8080'
+
 #MQTT parameters
 BROKER="local IP for your MQTT broker"
 PORT="port to use, i.e. 1883"

--- a/example.env
+++ b/example.env
@@ -13,7 +13,7 @@ export TESLA_VIN='Tesla VIN'
 export TESLA_KEY_FILE='private key location, i.e. /home/pi/.local/share/keyrings/private_key.pem'
 TESLA_CONTROL_BIN='Tesla control bin location, i.e. /home/pi/go/bin/tesla-control'
 
-#TeslaBleHttpProxy parameters
+#TeslaBleHttpProxy parameters (optional, enabled in config.toml)
 PROXY_HOST='proxy local ip:8080'
 
 #MQTT parameters

--- a/example_config.toml
+++ b/example_config.toml
@@ -2,6 +2,7 @@
 LOG_FILE = 'PVCharge.log'           # Log file name to use
 LOG_LEVEL = "INFO"                  # Default INFO, change to DEBUG to diagnose issues
 PREVENT_NON_SOLAR_CHARGE = "False"  # Default for after-hours charging, unless changed via MQTT
+ENABLE_TESLA_PROXY = "False"        # Optionally enable TeslaBleHttpProxy (requires additional parameter in .env, and a running proxy)
 
 # MQTT Control topics
 TOPIC_PREVENT_NON_SOLAR_CHARGE =   "topic_base/prevent_non_solar_charge"

--- a/routines.py
+++ b/routines.py
@@ -129,6 +129,7 @@ class PowerUsage:
                    str(math.floor(self.new_charge_rate)))
         return status
 
+
 class TeslaProxy:
     """Class to send commands to TeslaBleHttpProxy"""
     def __init__(self):
@@ -136,9 +137,15 @@ class TeslaProxy:
         self.tesla_vin = os.getenv("TESLA_VIN")
         self.tesla_proxy_host = os.getenv("PROXY_HOST")
         self.tesla_proxy_base_command = self.tesla_proxy_host + "/api/1/vehicles/" + self.tesla_vin + "/command/"
+        # Test for existence of TeslaBleHttpProxy
+        if self.tesla_proxy_host == None:
+            logging.critical("PROXY_HOST not configured")
+            logging.critical("Please point to TeslaBleHttpProxy in .env")
+            sys.exit(1)
 
     def set_charge_rate(self, charge_rate):
         command = self.tesla_proxy_base_command + "set_charging_amps"
+        logging.debug(command)
         data = {}
         data["charging_amps"] = charge_rate
         rc = call_http_post(command, data)
@@ -147,11 +154,13 @@ class TeslaProxy:
 
     def start_charging(self):
         command = self.tesla_proxy_base_command + "charge_start"
+        logging.debug(command)
         data = ""
         return call_http_post(command, data)
 
     def stop_charging(self):
         command = self.tesla_proxy_base_command + "charge_stop"
+        logging.debug(command)
         data = ""
         rc = call_http_post(command, data)
         time.sleep(5)
@@ -159,8 +168,10 @@ class TeslaProxy:
 
     def wake(self):
         command = self.tesla_proxy_base_command + "wake_up"
+        logging.debug(command)
         data = ""
         return call_http_post(command, data)
+
 
 def call_http_post(cmd, data):
     if data == "":
@@ -234,8 +245,7 @@ def call_sub_error_handler(cmd):
         elif "is_charging" in error.stderr:
             # We have a match for "car could not execute command: is_charging" (already charging condition)
             logging.info("Attempted to start charging when car was already charging!")
-            # Return True as this isn't really an error condition
-            return True, 0
+            return True, 0    # Return True as this isn't really an error condition
         elif "context deadline exceeded" in error.stderr:
             # We have a match for the timeout error
             logging.warning("Last Tesla command timed out")

--- a/routines.py
+++ b/routines.py
@@ -18,6 +18,11 @@ load_dotenv()
 with open("config.toml", mode="rb") as fp:
     config = tomllib.load(fp)
 
+# Test if we have parameters for TeslaBleHttpProxy
+if "ENABLE_TESLA_PROXY" in config:
+    tesla_proxy_config_exists = config["ENABLE_TESLA_PROXY"]
+else:
+    tesla_proxy_config_exists = "False"
 
 class PowerUsage:
     """Class to request data from the eGauge web API"""
@@ -296,7 +301,7 @@ class MqttCallbacks:
         self.var_topic_teslamate_charge_limit_soc = 0
         self.var_topic_teslamate_state = False
 
-        if config["ENABLE_TESLA_PROXY"] == "True":
+        if tesla_proxy_config_exists == "True":
             self.car_cmd = TeslaProxy()
         else:
             self.car_cmd = TeslaCommands()

--- a/routines.py
+++ b/routines.py
@@ -286,7 +286,10 @@ class MqttCallbacks:
         self.var_topic_teslamate_charge_limit_soc = 0
         self.var_topic_teslamate_state = False
 
-        self.car_cmd = TeslaProxy()
+        if config["ENABLE_TESLA_PROXY"] == True:
+            self.car_cmd = TeslaProxy()
+        else:
+            self.car_cmd = TeslaCommands()
 
         self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=self.client_id, protocol=mqtt.MQTTv311,
                                   clean_session=True)

--- a/routines.py
+++ b/routines.py
@@ -234,7 +234,8 @@ def call_sub_error_handler(cmd):
         elif "is_charging" in error.stderr:
             # We have a match for "car could not execute command: is_charging" (already charging condition)
             logging.info("Attempted to start charging when car was already charging!")
-            return True, 0    # Return True as this isn't really an error condition
+            # Return True as this isn't really an error condition
+            return True, 0
         elif "context deadline exceeded" in error.stderr:
             # We have a match for the timeout error
             logging.warning("Last Tesla command timed out")

--- a/routines.py
+++ b/routines.py
@@ -286,7 +286,7 @@ class MqttCallbacks:
         self.var_topic_teslamate_charge_limit_soc = 0
         self.var_topic_teslamate_state = False
 
-        self.car_cmd = TeslaCommands()
+        self.car_cmd = TeslaProxy()
 
         self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=self.client_id, protocol=mqtt.MQTTv311,
                                   clean_session=True)

--- a/routines.py
+++ b/routines.py
@@ -136,12 +136,12 @@ class TeslaProxy:
         # Load parameters from .env
         self.tesla_vin = os.getenv("TESLA_VIN")
         self.tesla_proxy_host = os.getenv("PROXY_HOST")
-        self.tesla_proxy_base_command = self.tesla_proxy_host + "/api/1/vehicles/" + self.tesla_vin + "/command/"
         # Test for existence of TeslaBleHttpProxy
         if self.tesla_proxy_host == None:
             logging.critical("PROXY_HOST not configured")
             logging.critical("Please point to TeslaBleHttpProxy in .env")
             sys.exit(1)
+        self.tesla_proxy_base_command = self.tesla_proxy_host + "/api/1/vehicles/" + self.tesla_vin + "/command/"
 
     def set_charge_rate(self, charge_rate):
         command = self.tesla_proxy_base_command + "set_charging_amps"

--- a/routines.py
+++ b/routines.py
@@ -165,8 +165,7 @@ def call_http_post(cmd, data):
         r = requests.post(url=cmd, json=data)
     if r.status_code == 200:    # good return code
         result = r.json()
-        print(result)
-        logging.info(result)
+        logging.debug(result)
     else:
         logging.warning(result)
     return result["response"]["result"]

--- a/routines.py
+++ b/routines.py
@@ -141,7 +141,9 @@ class TeslaProxy:
         command = self.tesla_proxy_base_command + "set_charging_amps"
         data = {}
         data["charging_amps"] = charge_rate
-        return call_http_post(command, data)
+        rc = call_http_post(command, data)
+        time.sleep(5)
+        return rc
 
     def start_charging(self):
         command = self.tesla_proxy_base_command + "charge_start"
@@ -151,7 +153,9 @@ class TeslaProxy:
     def stop_charging(self):
         command = self.tesla_proxy_base_command + "charge_stop"
         data = ""
-        return call_http_post(command, data)
+        rc = call_http_post(command, data)
+        time.sleep(5)
+        return rc
 
     def wake(self):
         command = self.tesla_proxy_base_command + "wake_up"

--- a/routines.py
+++ b/routines.py
@@ -286,7 +286,7 @@ class MqttCallbacks:
         self.var_topic_teslamate_charge_limit_soc = 0
         self.var_topic_teslamate_state = False
 
-        if config["ENABLE_TESLA_PROXY"] == True:
+        if config["ENABLE_TESLA_PROXY"] == "True":
             self.car_cmd = TeslaProxy()
         else:
             self.car_cmd = TeslaCommands()

--- a/routines.py
+++ b/routines.py
@@ -18,11 +18,6 @@ load_dotenv()
 with open("config.toml", mode="rb") as fp:
     config = tomllib.load(fp)
 
-# Test if we have parameters for TeslaBleHttpProxy
-if "ENABLE_TESLA_PROXY" in config:
-    tesla_proxy_config_exists = config["ENABLE_TESLA_PROXY"]
-else:
-    tesla_proxy_config_exists = "False"
 
 class PowerUsage:
     """Class to request data from the eGauge web API"""
@@ -301,8 +296,11 @@ class MqttCallbacks:
         self.var_topic_teslamate_charge_limit_soc = 0
         self.var_topic_teslamate_state = False
 
-        if tesla_proxy_config_exists == "True":
-            self.car_cmd = TeslaProxy()
+        if "ENABLE_TESLA_PROXY" in config:
+            if config["ENABLE_TESLA_PROXY"] == "True":
+                self.car_cmd = TeslaProxy()
+            else:
+                self.car_cmd = TeslaCommands()
         else:
             self.car_cmd = TeslaCommands()
 


### PR DESCRIPTION
TeslaBleHttpProxy may now be used instead of the built-in calls to the tesla-control command line.
To use, you will need a running [TeslaBleHttpProxy](https://github.com/wimaha/TeslaBleHttpProxy)
Add this parameter in .env
`PROXY_HOST='proxy local ip:8080'`
Add this parameter in config.toml
`ENABLE_TESLA_PROXY = "True"`